### PR TITLE
fix: make custom headerInfo working again

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -84,11 +84,16 @@
         continue
       }
       if k.contains("custom") {
-        let evaluatedV = eval(v)
-        // example value (icon: fa-graduation-cap(), text: "PhD", link: "https://www.example.com")
-        let icon = evaluatedV.at("icon", default: "")
-        let text = evaluatedV.at("text", default: "")
-        let link_value = evaluatedV.at("link", default: "")
+        let img = v.at("image", default: "")
+        let awesomeIcon = v.at("awesomeIcon", default: "")
+        let text = v.at("text", default: "")
+        let link_value = v.at("link", default: "")
+        let icon = ""
+        if img != "" {
+          icon = img.with(width: 10pt)
+        } else {
+          icon = fa-icon(awesomeIcon)
+        }
         box({
           icon
           h(5pt)
@@ -97,7 +102,8 @@
       } else if v != "" {
         box({
           // Adds icons
-          personalInfoIcons.at(k) + h(5pt)
+          personalInfoIcons.at(k)
+          h(5pt)
           // Adds hyperlinks
           if k == "email" {
             link("mailto:" + v)[#v]

--- a/cv.typ
+++ b/cv.typ
@@ -84,10 +84,11 @@
         continue
       }
       if k.contains("custom") {
+        let evaluatedV = eval(v)
         // example value (icon: fa-graduation-cap(), text: "PhD", link: "https://www.example.com")
-        let icon = v.at("icon", default: "")
-        let text = v.at("text", default: "")
-        let link_value = v.at("link", default: "")
+        let icon = evaluatedV.at("icon", default: "")
+        let text = evaluatedV.at("text", default: "")
+        let link_value = evaluatedV.at("link", default: "")
         box({
           icon
           h(5pt)

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -11,66 +11,71 @@ before_entry_skip = "1pt"
 before_entry_description_skip = "1pt"
 
 [layout.header]
-# Optional values: left, center, right
-header_align = "left"
+    # Optional values: left, center, right
+    header_align = "left"
 
- # Decide if you want to display profile photo or not
-display_profile_photo = true
-profile_photo_path = "template/src/avatar.png"
+    # Decide if you want to display profile photo or not
+    display_profile_photo = true
+    profile_photo_path = "template/src/avatar.png"
 
 [layout.entry]
-# Decide if you want to put your company in bold or your position in bold
-display_entry_society_first = true
+    # Decide if you want to put your company in bold or your position in bold
+    display_entry_society_first = true
 
-# Decide if you want to display organisation logo or not
-display_logo = true
+    # Decide if you want to display organisation logo or not
+    display_logo = true
 
 [inject]
-# Decide if you want to inject AI prompt or not
-inject_ai_prompt = false
+    # Decide if you want to inject AI prompt or not
+    inject_ai_prompt = false
 
-# Decide if you want to inject keywords or not
-inject_keywords = true
-injected_keywords_list = ["Data Analyst", "GCP", "Python", "SQL", "Tableau"]
+    # Decide if you want to inject keywords or not
+    inject_keywords = true
+    injected_keywords_list = ["Data Analyst", "GCP", "Python", "SQL", "Tableau"]
 
 [personal]
-first_name = "John"
-last_name = "Doe"
+    first_name = "John"
+    last_name = "Doe"
 
 # The order of this section will affect how the entries are displayed
-# The custom value is for any additional information you want to add
+# The custom value is for any additional information you want to add, name it as custom-1, custom-2, etc.
 [personal.info]
-github = "mintyfrankie"
-phone = "+33 6 12 34 56 78"
-email = "john.doe@me.org"
-linkedin = "johndoe"
-# gitlab = "mintyfrankie"
-# homepage = "jd.me.org"
-# orcid = "0000-0000-0000-0000"
-# researchgate = "John-Doe"
-# extraInfo = "I am a cool kid"
-custom-1 = "(icon: \"\", text: \"PhD\", link: \"https://www.example.com\")"
+    github = "mintyfrankie"
+    phone = "+33 6 12 34 56 78"
+    email = "john.doe@me.org"
+    linkedin = "johndoe"
+    # gitlab = "mintyfrankie"
+    # homepage = "jd.me.org"
+    # orcid = "0000-0000-0000-0000"
+    # researchgate = "John-Doe"
+    # extraInfo = "I am a cool kid"
+    [personal.info.custom-1]
+        # image = "" # Example: image("./path/to/image.png")
+        awesomeIcon = "graduation-cap" # Example: "graduation-cap" see https://typst.app/universe/package/fontawesome/
+        text = "PhD"
+        link = "https://www.example.com"
+
 
 # add a new section if you want to include the language of your choice
 # i.e. [[lang.ru]]
 # each section must contains the following fields
 [lang.en]
-header_quote = "Experienced Data Analyst looking for a full time job starting from now"
-cv_footer = "Curriculum vitae"
-letter_footer = "Cover letter"
+    header_quote = "Experienced Data Analyst looking for a full time job starting from now"
+    cv_footer = "Curriculum vitae"
+    letter_footer = "Cover letter"
 
 [lang.fr]
-header_quote = "Analyste de données expérimenté à la recherche d'un emploi à temps plein disponible dès maintenant"
-cv_footer = "Résumé"
-letter_footer = "Lettre de motivation"
+    header_quote = "Analyste de données expérimenté à la recherche d'un emploi à temps plein disponible dès maintenant"
+    cv_footer = "Résumé"
+    letter_footer = "Lettre de motivation"
 
 [lang.zh]
-header_quote = "具有丰富经验的数据分析师，随时可入职"
-cv_footer = "简历"
-letter_footer = "申请信"
+    header_quote = "具有丰富经验的数据分析师，随时可入职"
+    cv_footer = "简历"
+    letter_footer = "申请信"
 
  # For languages that are not written in Latin script
  # Currently supported non-latin language codes: ("zh", "ja", "ko", "ru")
 [lang.non_latin]
-name = "王道尔"
-font = "Heiti SC"
+    name = "王道尔"
+    font = "Heiti SC"

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -49,7 +49,7 @@ linkedin = "johndoe"
 # orcid = "0000-0000-0000-0000"
 # researchgate = "John-Doe"
 # extraInfo = "I am a cool kid"
-# custom-1 = (icon: "", text: "example", link: "https://example.com")
+custom-1 = "(icon: \"\", text: \"PhD\", link: \"https://www.example.com\")"
 
 # add a new section if you want to include the language of your choice
 # i.e. [[lang.ru]]


### PR DESCRIPTION
With the bumping to `v2`, the custom headerInfo functionality does not work anymore due to the change from `metadata.typ` to `metadata.toml`.