### PR TITLE
Fix custom accent color

### DIFF
--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -3,6 +3,7 @@ language = "en"
 
 [layout]
 # Optional values: skyblue, red, nephritis, concrete, darknight
+# You can also use a custom color by hex code i.e. "#1E90FF"
 awesome_color = "skyblue"
 
 # Skips are for controlling the spacing between sections and entries

--- a/utils/styles.typ
+++ b/utils/styles.typ
@@ -26,7 +26,7 @@
 
 #let setAccentColor(awesomeColors, metadata) = {
   let param = metadata.layout.awesome_color
-  return if type(param) == color {
+  return if type(eval(param)) == color {
     param
   } else {
     awesomeColors.at(param)

--- a/utils/styles.typ
+++ b/utils/styles.typ
@@ -26,9 +26,9 @@
 
 #let setAccentColor(awesomeColors, metadata) = {
   let param = metadata.layout.awesome_color
-  return if type(eval(param)) == color {
-    param
-  } else {
+  return if param in awesomeColors {
     awesomeColors.at(param)
+  } else {
+    rgb(param)
   }
 }


### PR DESCRIPTION
Currently, when setting a custom accent color in `metadata.toml`, with something like
```toml
[layout]
awesome_color = 'rgb(#FF00AA)'
```

the code in `setAccentColor` checks for the type of the parameter.

Problem is, if you try getting the type of param with something like
```typst
#let metadata = toml("/metadata.toml")
#type(metadata.layout.awesome_color)
```

it will always print out `string`, so the function will always try to use one of `awesomeColors`