### PR TITLE
fix!(template): correct profile photo import logic

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -14,7 +14,7 @@
 /// - regularColors (array): the regular colors of the CV.
 /// - awesomeColors (array): the awesome colors of the CV.
 /// -> content
-#let _cvHeader(metadata, headerFont, regularColors, awesomeColors) = {
+#let _cvHeader(metadata, profilePhoto, headerFont, regularColors, awesomeColors) = {
   // Parameters
   let hasPhoto = metadata.layout.header.display_profile_photo
   let align = eval(metadata.layout.header.header_align)
@@ -26,7 +26,7 @@
   let lastName = metadata.personal.last_name
   let headerQuote = metadata.lang.at(metadata.language).header_quote
   let displayProfilePhoto = metadata.layout.header.display_profile_photo
-  let profilePhotoPath = metadata.layout.header.profile_photo_path
+  // let profilePhoto = metadata.layout.header.profile_photo_path
   let accentColor = setAccentColor(awesomeColors, metadata)
   let nonLatinName = ""
   let nonLatin = isNonLatin(metadata.language)
@@ -145,8 +145,9 @@
   )
 
   let makeHeaderPhotoSection() = {
+    set image(height: 3.6cm)
     if displayProfilePhoto {
-      box(image(profilePhotoPath, height: 3.6cm), radius: 50%, clip: true)
+      box(profilePhoto, radius: 50%, clip: true)
     } else {
       v(3.6cm)
     }

--- a/lib.typ
+++ b/lib.typ
@@ -8,7 +8,10 @@
 #import "./utils/lang.typ": *
 
 /* Layout */
-#let cv(metadata, doc) = {
+#let cv(
+  metadata, 
+  profilePhoto: image("./template/src/avatar.png"),
+  doc) = {
   // Non Latin Logic
   let lang = metadata.language
   let fontList = latinFontList
@@ -27,7 +30,7 @@
     margin: (left: 1.4cm, right: 1.4cm, top: .8cm, bottom: .4cm),
   )
 
-  _cvHeader(metadata, headerFont, regularColors, awesomeColors)
+  _cvHeader(metadata, profilePhoto, headerFont, regularColors, awesomeColors)
   doc
   _cvFooter(metadata)
 }

--- a/metadata.toml.schema.json
+++ b/metadata.toml.schema.json
@@ -49,7 +49,7 @@
                 "description": "Path to the profile photo"
               }
             },
-            "required": ["header_align", "display_profile_photo", "profile_photo_path"]
+            "required": ["header_align", "display_profile_photo"]
           },
           "entry": {
             "type": "object",

--- a/template/cv.typ
+++ b/template/cv.typ
@@ -10,7 +10,10 @@
 }
 
 
-#show: cv.with(metadata)
+#show: cv.with(
+  metadata, 
+  profilePhoto: image("./src/avatar.png")
+)
 #importModules((
   "education",
   "professional",

--- a/template/metadata.toml
+++ b/template/metadata.toml
@@ -20,7 +20,6 @@ language = "en"
 
         # Decide if you want to display profile photo or not
         display_profile_photo = true
-        profile_photo_path = "template/src/avatar.png"
 
     [layout.entry]
         # Decide if you want to put your company in bold or your position in bold


### PR DESCRIPTION
Fix #42 

BREAKING CHANGES
- due to Typst path handling mecanism, the current implementation for importing profile photo is broken.
- a hotfix is to be patched to import the image function at cv.typ level instead of metadata.toml
- this fix is not ideal, and will be reverted/changed once Typst introduces better solution