### PR TITLE
fix(cv): delete trailing comma in header name in non-latin

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -137,9 +137,9 @@
     inset: 0pt,
     stroke: none,
     row-gutter: 6mm,
-    if nonLatin [
-      #headerFirstNameStyle(nonLatinName),
-    ] else [#headerFirstNameStyle(firstName) #h(5pt) #headerLastNameStyle(lastName)],
+    if nonLatin {
+      headerFirstNameStyle(nonLatinName)
+    } else [#headerFirstNameStyle(firstName) #h(5pt) #headerLastNameStyle(lastName)],
     [#headerInfoStyle(makeHeaderInfo())],
     [#headerQuoteStyle(headerQuote)],
   )


### PR DESCRIPTION
Fix #52